### PR TITLE
Add email invite when creating organizations

### DIFF
--- a/src/lib/mailer.ts
+++ b/src/lib/mailer.ts
@@ -1,0 +1,19 @@
+export interface InviteEmailOptions {
+  to: string;
+  firstName: string;
+  lastName: string;
+  tempPassword: string;
+}
+
+export async function sendInviteEmail(options: InviteEmailOptions) {
+  const appUrl = process.env.APP_URL || 'http://localhost:3000';
+  console.log('[Email]', {
+    to: options.to,
+    subject: 'Your administrator account',
+    text: `Hello ${options.firstName} ${options.lastName},\n\n` +
+      `Your organization account has been created.\n` +
+      `Login: ${options.to}\n` +
+      `Temporary password: ${options.tempPassword}\n` +
+      `Please log in at ${appUrl}/login and change your password.`,
+  });
+}


### PR DESCRIPTION
## Summary
- add minimal mailer helper
- create firebase admin user and send invite email when creating an organization

## Testing
- `npm run typecheck` *(fails: Property 'username' does not exist on type 'User', etc.)*
- `npm run lint` *(prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_b_684f130d821c832a8151971003c96f95